### PR TITLE
fix(ci): use ADMIN_TOKEN for release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,31 +18,42 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN }}
+
+      - name: Check if should skip
+        id: check_skip
+        run: |
+          if [ "$(git log -1 --pretty=format:'%an')" = "semantic-release" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up Python
+        if: steps.check_skip.outputs.skip != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Install uv
+        if: steps.check_skip.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v4
 
       - name: Python Semantic Release
+        if: steps.check_skip.outputs.skip != 'true'
         id: release
         uses: python-semantic-release/python-semantic-release@v9.15.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Build package
-        if: steps.release.outputs.released == 'true'
+        if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'
         run: uv build
 
       - name: Publish to PyPI
-        if: steps.release.outputs.released == 'true'
+        if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Publish to GitHub Releases
-        if: steps.release.outputs.released == 'true'
+        if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'
         uses: python-semantic-release/publish-action@v9.15.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION
## Summary

- Use org-level `ADMIN_TOKEN` instead of `GITHUB_TOKEN` for semantic-release
- Add skip-check to prevent infinite loops on release commits

## Root cause

The release workflow for PR #22 (submodule removal) just failed because `GITHUB_TOKEN` can't push the version-bump commit to main (branch protection requires PRs). Same fix as applied to openadapt-evals and openadapt-capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)