### PR TITLE
docs: add experimental roadmap and evidence context to vision

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -23,7 +23,7 @@ because:
 
 | | No Retrieval | With Retrieval |
 |---|---|---|
-| **No Fine-tuning** | 33–47% (baseline) | **100%** (validated) |
+| **No Fine-tuning** | 46.7% (baseline) | **100%** (validated) |
 | **Fine-tuning** | Standard SFT (baseline) | **Demo-conditioned FT** (unique value) |
 
 Phase 2 (retrieval-only) is validated. Phase 3 (demo-conditioned fine-tuning — training models to *use* demonstrations they haven't seen) is the core planned work.


### PR DESCRIPTION
## Summary
- Add 2×2 experimental matrix (retrieval × fine-tuning) to Core Thesis in vision.md
- Add evidence context to benchmark table: note it's an internal synthetic benchmark that validates the pipeline, not real-world performance

## Why
Honest scoping of claims. The benchmark results are real but should be framed as "pipeline validated" not "production-proven." Links to openadapt-evals for ongoing WAA/OSWorld evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)