### PR TITLE
docs: add lifecycle status banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # OpenAdapt-ML
 
+> [!IMPORTANT]
+> **Status: Research — not required by the product.** This package explores
+> training and running demo-conditioned vision-language model (VLM) agents for
+> GUI automation. It is evidence-generating research work and is not required
+> to record, compile, or replay a workflow.
+>
+> The OpenAdapt product is the demonstration compiler,
+> [`openadapt-flow`](https://github.com/OpenAdaptAI/openadapt-flow), installed
+> via the [`OpenAdapt`](https://github.com/OpenAdaptAI/OpenAdapt) launcher
+> (`pip install openadapt`): it compiles a demonstrated GUI workflow into a
+> deterministic, locally executable program. Healthy runs make no model calls,
+> and it halts instead of guessing when verification fails. Lifecycle labels for
+> every repository are in the
+> [repository lifecycle registry](https://github.com/OpenAdaptAI/.github/blob/main/REPOSITORY_LIFECYCLE.md).
+
 [![Tests](https://github.com/OpenAdaptAI/openadapt-ml/actions/workflows/test.yml/badge.svg)](https://github.com/OpenAdaptAI/openadapt-ml/actions/workflows/test.yml)
 [![PyPI version](https://img.shields.io/pypi/v/openadapt-ml.svg)](https://pypi.org/project/openadapt-ml/)
 [![Downloads](https://img.shields.io/pypi/dm/openadapt-ml.svg)](https://pypi.org/project/openadapt-ml/)


### PR DESCRIPTION
The [repository lifecycle registry](https://github.com/OpenAdaptAI/.github/blob/main/REPOSITORY_LIFECYCLE.md) (reviewed 2026-07-15) classifies this repo as **Research**, but the README carried no lifecycle banner, unlike the ~9 repos covered by the earlier banner wave.

This adds the standard `[!IMPORTANT]` banner directly below the title, with status wording derived from the registry classification and the same product-pointer paragraph used on the other banners (openadapt-capture, openadapt-grounding, openadapt-retrieval). All existing README content is intact below the banner.

Part of the org-hygiene wave from the 2026-07-17 licensing/lifecycle audit. Do not merge without maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)