### PR TITLE
fix: preserve benchmark agent failures

### DIFF
--- a/openadapt_ml/benchmarks/agent.py
+++ b/openadapt_ml/benchmarks/agent.py
@@ -325,7 +325,7 @@ Then output the action on a new line starting with "ACTION:"
         try:
             response = adapter.generate(sample, max_new_tokens=self.max_tokens)
         except Exception as e:
-            return BenchmarkAction(type="done", raw_action={"error": str(e)})
+            return BenchmarkAction(type="error", raw_action={"error": str(e)})
 
         return self._parse_response(response, observation)
 
@@ -451,7 +451,7 @@ Then output the action on a new line starting with "ACTION:"
 
         if not action_line:
             raw_action["parse_error"] = "No action pattern found"
-            return BenchmarkAction(type="done", raw_action=raw_action)
+            return BenchmarkAction(type="error", raw_action=raw_action)
 
         # Parse CLICK([id])
         click_match = re.match(
@@ -557,7 +557,7 @@ Then output the action on a new line starting with "ACTION:"
             )
 
         raw_action["parse_error"] = f"Unknown action format: {action_line}"
-        return BenchmarkAction(type="done", raw_action=raw_action)
+        return BenchmarkAction(type="error", raw_action=raw_action)
 
     def reset(self) -> None:
         """Reset agent state."""
@@ -661,7 +661,7 @@ class UnifiedBaselineAgent(BenchmarkAgent):
         except Exception as e:
             if self.verbose:
                 print(f"[UnifiedBaselineAgent] Adapter error: {e}")
-            return BenchmarkAction(type="done", raw_action={"error": str(e)})
+            return BenchmarkAction(type="error", raw_action={"error": str(e)})
 
         return self._parsed_to_benchmark_action(parsed_action, observation)
 
@@ -693,7 +693,7 @@ class UnifiedBaselineAgent(BenchmarkAgent):
 
         if not parsed_action.is_valid:
             raw_action["parse_error"] = parsed_action.parse_error
-            return BenchmarkAction(type="done", raw_action=raw_action)
+            return BenchmarkAction(type="error", raw_action=raw_action)
 
         action_type = parsed_action.action_type
 
@@ -743,7 +743,7 @@ class UnifiedBaselineAgent(BenchmarkAgent):
             )
 
         raw_action["unknown_action"] = action_type
-        return BenchmarkAction(type="done", raw_action=raw_action)
+        return BenchmarkAction(type="error", raw_action=raw_action)
 
     def reset(self) -> None:
         """Reset agent state."""

--- a/openadapt_ml/experiments/waa_demo/runner.py
+++ b/openadapt_ml/experiments/waa_demo/runner.py
@@ -318,7 +318,7 @@ Think step by step, then output the action on a new line starting with "ACTION:"
         except Exception as e:
             logger.error(f"API error: {e}")
             return BenchmarkAction(
-                type="done",
+                type="error",
                 raw_action={"error": str(e)},
             )
 
@@ -473,7 +473,7 @@ Think step by step, then output the action on a new line starting with "ACTION:"
 
         if not action_line:
             raw_action["parse_error"] = "No action pattern found"
-            return BenchmarkAction(type="done", raw_action=raw_action)
+            return BenchmarkAction(type="error", raw_action=raw_action)
 
         # Parse CLICK with element ID
         click_id_match = re.match(
@@ -538,7 +538,7 @@ Think step by step, then output the action on a new line starting with "ACTION:"
             return BenchmarkAction(type="done", raw_action=raw_action)
 
         raw_action["parse_error"] = f"Unknown action format: {action_line}"
-        return BenchmarkAction(type="done", raw_action=raw_action)
+        return BenchmarkAction(type="error", raw_action=raw_action)
 
     def reset(self) -> None:
         """Reset agent state between episodes."""

--- a/tests/test_agent_failure_actions.py
+++ b/tests/test_agent_failure_actions.py
@@ -1,0 +1,53 @@
+"""Agent infrastructure and parse failures must not look like task completion."""
+
+from __future__ import annotations
+
+from openadapt_types import BenchmarkObservation, BenchmarkTask
+
+from openadapt_ml.baselines import ParsedAction
+from openadapt_ml.benchmarks.agent import APIBenchmarkAgent, UnifiedBaselineAgent
+from openadapt_ml.experiments.waa_demo.runner import DemoConditionedAgent
+
+
+class _FailingAdapter:
+    def generate(self, *args, **kwargs):
+        raise RuntimeError("provider unavailable")
+
+    def predict(self, *args, **kwargs):
+        raise RuntimeError("provider unavailable")
+
+
+def _observation_and_task():
+    return BenchmarkObservation(), BenchmarkTask(
+        task_id="task-1", instruction="Complete the task", domain="desktop"
+    )
+
+
+def test_api_agent_preserves_provider_and_parse_failures():
+    observation, task = _observation_and_task()
+    agent = APIBenchmarkAgent()
+    agent._adapter = _FailingAdapter()
+
+    assert agent.act(observation, task).type == "error"
+    assert agent._parse_response("not an action").type == "error"
+    assert agent._parse_response("ACTION: UNKNOWN(foo)").type == "error"
+
+
+def test_unified_agent_preserves_provider_and_parse_failures():
+    observation, task = _observation_and_task()
+    agent = UnifiedBaselineAgent()
+    agent._adapter = _FailingAdapter()
+
+    assert agent.act(observation, task).type == "error"
+    invalid = ParsedAction(action_type="unknown", parse_error="not an action")
+    assert agent._parsed_to_benchmark_action(invalid).type == "error"
+
+
+def test_demo_agent_preserves_provider_and_parse_failures():
+    observation, task = _observation_and_task()
+    agent = DemoConditionedAgent()
+    agent._adapter = _FailingAdapter()
+
+    assert agent.act(observation, task).type == "error"
+    assert agent._parse_response("not an action").type == "error"
+    assert agent._parse_response("ACTION: UNKNOWN(foo)").type == "error"


### PR DESCRIPTION
## What changed

- Return terminal `error` actions when hosted VLM calls fail.
- Return terminal `error` actions when API, unified-baseline, or WAA demo responses cannot be parsed.
- Preserve explicit model-issued completion as `done`.

## Why

The benchmark action schema already supports `error`, and the evaluation adapters handle it as a distinct terminal state. Returning `done` for provider and parse failures made task completion and agent failure indistinguishable.

## Validation

- 470 unit tests passed; 5 skipped.
- 77 focused failure and baseline tests passed.
- Ruff and formatting checks passed for every changed file.
- `git diff --check` passed.
- The optional integration collection requires `openadapt-evals`, which is not installed in this worktree environment.
