### PR TITLE
ci: pin pypa/gh-action-pypi-publish to a commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,14 @@ jobs:
           uv build
           python scripts/check_source_boundary.py --require-dist
 
+      # Pinned to a commit SHA, not the floating release/v1 tag, so an upstream
+      # change cannot alter a release with no commit here. v1.14.2 bundles twine
+      # 7.0.0 and packaging 26.2, which accept the Metadata-Version 2.5 that current
+      # hatchling emits. v1.14.0 rejected it and broke the openadapt-evals 0.91.0
+      # publish after the tag had already landed.
       - name: Publish to PyPI
         if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
       - name: Publish to GitHub Releases
         if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Problem

This workflow referenced the publish action by the floating `release/v1` tag:

```yaml
uses: pypa/gh-action-pypi-publish@release/v1
```

Every other release pipeline in the org pins a full 40-character commit SHA. A floating tag means upstream can change what runs in a release here with **no commit in this repo** — including a change that breaks publishing outright.

That risk is not theoretical. **v1.14.0** bundles twine 6.1.0 and packaging 25.0, which reject `Metadata-Version: 2.5` — the version current hatchling emits:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

That pin broke the **openadapt-evals 0.91.0** release: the tag, the version commit and the GitHub release all landed, then `Publish to PyPI` failed — leaving PyPI stale while every other artifact claimed the version had shipped.

## Fix

Pin `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` (**v1.14.2**, twine 7.0.0 + packaging 26.2), with a comment recording why.

This is not an untested guess. v1.14.2 is the pin already used by OpenAdapt, openadapt-agent, openadapt-capture, openadapt-desktop, openadapt-evals, openadapt-flow and openadapt-tray, and it was just proven end to end by **live PyPI uploads of `openadapt-privacy` 1.0.3 and `openadapt-types` 0.10.1** — both logged `Checking dist/…: PASSED` on the exact metadata check that v1.14.0 fails.

## Verification

The tag was resolved against upstream rather than copied: `v1.14.2` → `dc37677b2e1c63e2034f94d8a5b11f265b73ba33`. The workflow still parses as valid YAML.

## No release is cut

The title is `ci:`, and `patch_tags` is `["fix", "perf"]` — so this merges without cutting a release. That is deliberate: this repo is not currently broken (`release/v1` floats to a working version today), so there is no failure to prove fixed, and the pin is already validated elsewhere. The new pin takes effect at this repo's next real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
