### PR TITLE
docs: lead with research, not VLM-agent training

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # openadapt-ml
 
 > [!IMPORTANT]
-> **Status: Research. Not required by the product.** This package trains and
-> runs vision-language model agents for GUI automation. You do not need it to
-> record, compile, or replay a workflow. That is
-> [openadapt-flow](https://github.com/OpenAdaptAI/openadapt-flow), installed by
-> the [OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt) launcher. Lifecycle
-> labels for every repository are in the
+> **Research. Optional VLM training. Not the OpenAdapt product.** This package
+> is not required to record, compile, or replay a workflow. The product is a
+> compiled program:
+> [openadapt-flow](https://github.com/OpenAdaptAI/openadapt-flow) via
+> `pip install openadapt`. Lifecycle labels for every repository are in the
 > [repository lifecycle registry](https://github.com/OpenAdaptAI/.github/blob/main/REPOSITORY_LIFECYCLE.md).
 
 [![Tests](https://github.com/OpenAdaptAI/openadapt-ml/actions/workflows/test.yml/badge.svg)](https://github.com/OpenAdaptAI/openadapt-ml/actions/workflows/test.yml)


### PR DESCRIPTION
The IMPORTANT banner still opened with "trains and runs vision-language model agents." That's this package. It isn't the product, and the first ten lines are what models quote.

Rewrote only that block. The rest of the README is the same.

GitHub About is already:

Research. Optional VLM training. Not required to record, compile, or replay. The product is a compiled program (openadapt-flow / pip install openadapt).

Opened/edited by an agent session, not the founder.
